### PR TITLE
Restore calibrate and generate_board tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,9 @@ cargo run --bin camera_server     # Mac側: カメラキャプチャ + TCP送信
 cargo run --bin inference_server  # Win側: 推論 + 三角測量 + VMT送信
 
 # ツール
-cargo run --bin camera_probe  # カメラデバイス検出
+cargo run --bin camera_probe    # カメラデバイス検出
+cargo run --bin calibrate       # ChArUcoキャリブレーション（設定: config.toml）
+cargo run --bin generate_board  # ChArUcoボード画像生成
 ```
 
 ## What This Project Does
@@ -35,6 +37,10 @@ Mac (camera_server) --TCP:9000--> Windows (inference_server) --OSC/UDP:39570--> 
 - `vmt` - VMTへのOSC送信。`/VMT/Room/Unity`アドレスでトラッカーの位置(x,y,z)と回転(quaternion)を送信
 - `triangulation` - DLT三角測量（CameraParams, triangulate_point, reprojection_error）
 - `pose` - キーポイント定義、クロップ領域、レターボックス補正
+- `calibration` - ChArUcoボードによるカメラキャリブレーション（imgproc feature）
+- `camera` - OpenCvCamera / ThreadedCamera（imgproc feature）
+- `render` - MinifbRenderer・骨格描画（imgproc feature）
+- `config` - キャリブレーション設定（config.toml）
 
 ### Data Flow
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,12 @@ checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
@@ -276,6 +282,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,6 +365,21 @@ dependencies = [
  "pem-rfc7468",
  "zeroize",
 ]
+
+[[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dunce"
@@ -721,6 +752,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "interpolate_name"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,6 +810,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "lebe"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,6 +835,27 @@ checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
 dependencies = [
  "arbitrary",
  "cc",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+ "redox_syscall 0.7.2",
 ]
 
 [[package]]
@@ -849,6 +919,44 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "minifb"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1a093126f2ed9012fc0b146934c97eb0273e54983680a8bf5309b6b4a365b32"
+dependencies = [
+ "cc",
+ "console_error_panic_hook",
+ "dlib",
+ "futures",
+ "instant",
+ "js-sys",
+ "lazy_static",
+ "libc",
+ "orbclient",
+ "raw-window-handle",
+ "serde",
+ "serde_derive",
+ "tempfile",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wayland-client",
+ "wayland-cursor",
+ "wayland-protocols",
+ "web-sys",
+ "winapi",
+ "x11-dl",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -951,6 +1059,18 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+]
 
 [[package]]
 name = "nom"
@@ -1083,7 +1203,7 @@ version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1119,6 +1239,17 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "orbclient"
+version = "0.3.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ad2c6bae700b7aa5d1cc30c59bdd3a1c180b09dbaea51e2ae2b8e1cf211fdd"
+dependencies = [
+ "libc",
+ "libredox",
+ "sdl2",
 ]
 
 [[package]]
@@ -1163,7 +1294,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -1219,7 +1350,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -1397,6 +1528,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-window-handle"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1428,7 +1565,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d94dd2f7cd932d4dc02cc8b2b50dfd38bd079a4e5d79198b99743d7fcf9a4b4"
+dependencies = [
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -1496,7 +1642,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1563,10 +1709,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdl2"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d42407afc6a8ab67e36f92e80b8ba34cbdc55aaeed05249efe9a2e8d0e9feef"
+dependencies = [
+ "bitflags 1.3.2",
+ "lazy_static",
+ "libc",
+ "sdl2-sys",
+]
+
+[[package]]
+name = "sdl2-sys"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff61407fc75d4b0bbc93dc7e4d6c196439965fbef8e4a4f003a36095823eac0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "version-compare",
+]
 
 [[package]]
 name = "security-framework"
@@ -1574,7 +1749,7 @@ version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1769,6 +1944,7 @@ dependencies = [
  "chrono",
  "futures",
  "image",
+ "minifb",
  "nalgebra",
  "ndarray",
  "opencv",
@@ -2002,6 +2178,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "version-compare"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2025,8 +2207,24 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
+ "serde_json",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2059,6 +2257,89 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3b068c05a039c9f755f881dc50f01732214f5685e379829759088967c46715"
+dependencies = [
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "libc",
+ "nix",
+ "scoped-tls",
+ "wayland-commons",
+ "wayland-scanner",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-commons"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8691f134d584a33a6606d9d717b95c4fa20065605f798a3f350d78dced02a902"
+dependencies = [
+ "nix",
+ "once_cell",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-cursor"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6865c6b66f13d6257bef1cd40cbfe8ef2f150fb8ebbdb1e8e873455931377661"
+dependencies = [
+ "nix",
+ "wayland-client",
+ "xcursor",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b950621f9354b322ee817a23474e479b34be96c2e909c14f7bc0100e9a970bc6"
+dependencies = [
+ "bitflags 1.3.2",
+ "wayland-client",
+ "wayland-commons",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4303d8fa22ab852f789e75a967f0a2cdc430a607751c0499bada3e451cbd53"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "xml-rs",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be12ce1a3c39ec7dba25594b97b42cb3195d54953ddb9d3d95a7c3902bc6e9d4"
+dependencies = [
+ "dlib",
+ "lazy_static",
+ "pkg-config",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2359,6 +2640,29 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "x11-dl"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f"
+dependencies = [
+ "libc",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
+name = "xcursor"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
+
+[[package]]
+name = "xml-rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "y4m"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ rosc = "0.10"      # OSCプロトコル（VMT連携）
 anyhow = "1.0"     # エラーハンドリング
 ort = { version = "2.0.0-rc.9", default-features = false, features = ["std", "ndarray", "tracing", "download-binaries", "copy-dylibs", "tls-rustls"] } # ONNX Runtime
 ndarray = "0.17"   # テンソル操作
-opencv = { version = "0.93", default-features = false, features = ["imgproc", "imgcodecs"], optional = true }
+opencv = { version = "0.93", default-features = false, features = ["imgproc", "imgcodecs", "calib3d", "objdetect"], optional = true }
+minifb = "0.28"
 image = "0.25"
 toml = "0.9.11"
 serde = { version = "1.0.228", features = ["derive"] }
@@ -36,6 +37,16 @@ ort = { version = "2.0.0-rc.9", features = ["directml"] }
 [[bin]]
 name = "camera_probe"
 path = "src/bin/camera_probe.rs"
+
+[[bin]]
+name = "calibrate"
+path = "src/bin/calibrate.rs"
+required-features = ["desktop"]
+
+[[bin]]
+name = "generate_board"
+path = "src/bin/generate_board.rs"
+required-features = ["imgproc"]
 
 [[bin]]
 name = "camera_server"

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,8 @@
+[calibration]
+dictionary = "DICT_4X4_50"
+squares_x = 5
+squares_y = 4
+square_length = 0.035   # チェスボードのマス辺長（メートル）
+marker_length = 0.025   # マス内ArUcoマーカー辺長（メートル）
+output_path = "calibration.json"
+intrinsic_frames = 15

--- a/src/bin/calibrate.rs
+++ b/src/bin/calibrate.rs
@@ -1,0 +1,535 @@
+use anyhow::{bail, Result};
+use minifb::Key;
+use opencv::core::{Mat, Size, Scalar};
+use opencv::{calib3d, prelude::*};
+use std::time::Instant;
+
+use talava_tracker::calibration::{
+    BoardParams, CameraCalibration, MultiCameraCalibration,
+    create_board, create_detector, detect_charuco_corners,
+    calibrate_intrinsics, estimate_pose, compute_relative_poses,
+    mat3x3_to_array, mat_to_vec, save_calibration,
+};
+use talava_tracker::camera::{OpenCvCamera, ThreadedCamera, detect_cameras};
+use talava_tracker::config::Config;
+use talava_tracker::render::MinifbRenderer;
+
+const CONFIG_PATH: &str = "config.toml";
+
+fn parse_camera_args() -> Option<Vec<i32>> {
+    let args: Vec<String> = std::env::args().collect();
+    // Usage: calibrate [camera_index ...]
+    // e.g.  calibrate 0 2
+    if args.len() <= 1 {
+        return None;
+    }
+    let indices: Vec<i32> = args[1..]
+        .iter()
+        .filter_map(|s| s.parse().ok())
+        .collect();
+    if indices.is_empty() { None } else { Some(indices) }
+}
+
+fn main() -> Result<()> {
+    let config = Config::load(CONFIG_PATH)?;
+    let cal_config = &config.calibration;
+
+    println!("=== ChArUco キャリブレーションツール ===");
+    println!();
+    println!("ボード設定:");
+    println!("  辞書: {}", cal_config.dictionary);
+    println!("  マス数: {}x{}", cal_config.squares_x, cal_config.squares_y);
+    println!("  マス辺長: {}m", cal_config.square_length);
+    println!("  マーカー辺長: {}m", cal_config.marker_length);
+    println!("  出力先: {}", cal_config.output_path);
+    println!("  内部パラメータ用フレーム数: {}", cal_config.intrinsic_frames);
+    println!();
+
+    // [1/4] カメラ検出・選択
+    let camera_indices = if let Some(manual) = parse_camera_args() {
+        println!("[1/4] カメラ指定: {:?}", manual);
+        manual
+    } else {
+        println!("[1/4] カメラ検出中...");
+        let found = detect_cameras(10);
+        if found.is_empty() {
+            bail!("カメラが見つかりません");
+        }
+        println!("  検出: {:?}", found);
+
+        if found.len() == 1 {
+            found
+        } else {
+            // プレビュー付きカメラ選択
+            // 各ウィンドウで映像を確認し、そのウィンドウでSpaceを押して選択/解除
+            println!();
+            println!("  カメラ選択:");
+            println!("  [Space] そのウィンドウのカメラを選択/解除");
+            println!("  [Enter] 確定  [Q] 中止");
+            println!();
+
+            let mut cameras: Vec<OpenCvCamera> = Vec::new();
+            let mut renderers: Vec<MinifbRenderer> = Vec::new();
+            let mut selected = vec![false; found.len()];
+
+            for &idx in &found {
+                let mut cam = OpenCvCamera::open_with_resolution(idx, Some(1280), Some(960))?;
+                // 実フレームサイズを取得してウィンドウを合わせる
+                let first_frame = cam.read_frame()?;
+                let fw = first_frame.cols() as usize;
+                let fh = first_frame.rows() as usize;
+                renderers.push(MinifbRenderer::new(
+                    &format!("Camera {}", idx),
+                    fw,
+                    fh,
+                )?);
+                cameras.push(cam);
+            }
+
+            let mut confirmed = false;
+            while !confirmed && renderers.iter().any(|r| r.is_open()) {
+                for (i, cam) in cameras.iter_mut().enumerate() {
+                    let frame = match cam.read_frame() {
+                        Ok(f) => f,
+                        Err(_) => continue,
+                    };
+
+                    let mut display = frame.clone();
+
+                    // 選択状態のオーバーレイ
+                    if selected[i] {
+                        // 緑枠
+                        let h = display.rows();
+                        let w = display.cols();
+                        let green = Scalar::new(0.0, 255.0, 0.0, 0.0);
+                        let thickness = 6;
+                        opencv::imgproc::rectangle(
+                            &mut display,
+                            opencv::core::Rect::new(0, 0, w, h),
+                            green, thickness, opencv::imgproc::LINE_8, 0,
+                        )?;
+                        opencv::imgproc::put_text(
+                            &mut display, "SELECTED",
+                            opencv::core::Point::new(10, 30),
+                            opencv::imgproc::FONT_HERSHEY_SIMPLEX, 0.8,
+                            green, 2, opencv::imgproc::LINE_8, false,
+                        )?;
+                    } else {
+                        opencv::imgproc::put_text(
+                            &mut display, "Space: select",
+                            opencv::core::Point::new(10, 30),
+                            opencv::imgproc::FONT_HERSHEY_SIMPLEX, 0.7,
+                            Scalar::new(200.0, 200.0, 200.0, 0.0),
+                            2, opencv::imgproc::LINE_8, false,
+                        )?;
+                    }
+
+                    renderers[i].draw_frame(&display)?;
+                    renderers[i].update()?;
+
+                    // そのウィンドウでSpaceが押されたらトグル
+                    if renderers[i].is_key_pressed(Key::Space) {
+                        selected[i] = !selected[i];
+                    }
+                }
+
+                if renderers.iter().any(|r| r.is_key_pressed(Key::Enter)) {
+                    if selected.iter().any(|&s| s) {
+                        confirmed = true;
+                    } else {
+                        println!("  1台以上選択してください");
+                    }
+                }
+                if renderers.iter().any(|r| r.is_key_pressed(Key::Q)) {
+                    bail!("ユーザーにより中止されました");
+                }
+            }
+
+            if !confirmed {
+                bail!("カメラ選択が完了しませんでした");
+            }
+
+            let chosen: Vec<i32> = found.iter().zip(selected.iter())
+                .filter(|(_, &sel)| sel)
+                .map(|(&idx, _)| idx)
+                .collect();
+            println!("  選択: {:?}", chosen);
+            chosen
+        }
+    };
+    println!();
+
+    // ボード作成
+    let board = create_board(cal_config)?;
+    let detector = create_detector(&board)?;
+
+    let num_cameras = camera_indices.len();
+
+    // [2/4] 内部パラメータキャリブレーション
+    println!("[2/4] 内部パラメータキャリブレーション");
+    println!("  各カメラでChArUcoボードを様々な角度から見せてください");
+    println!("  6コーナー以上検出されると自動キャプチャします（2秒間隔）");
+    println!("  [Q] 中止");
+    println!();
+
+    let capture_interval = std::time::Duration::from_millis(500);
+
+    let mut camera_matrices: Vec<Mat> = Vec::new();
+    let mut dist_coeffs_vec: Vec<Mat> = Vec::new();
+    let mut image_sizes: Vec<Size> = Vec::new();
+    let mut reprojection_errors: Vec<f64> = Vec::new();
+
+    for (cam_idx, &cam_id) in camera_indices.iter().enumerate() {
+        println!("--- カメラ {} ({}/{}) ---", cam_id, cam_idx + 1, num_cameras);
+
+        let camera = ThreadedCamera::start(cam_id, Some(1280), Some(960))?;
+        let (w, h) = camera.resolution();
+        let image_size = Size::new(w as i32, h as i32);
+        image_sizes.push(image_size);
+
+        let mut renderer = MinifbRenderer::new(
+            &format!("Calibrate - Camera {}", cam_id),
+            w as usize,
+            h as usize,
+        )?;
+
+        let mut all_corners: Vec<Mat> = Vec::new();
+        let mut all_ids: Vec<Mat> = Vec::new();
+        let mut last_capture = Instant::now() - capture_interval; // 初回は即キャプチャ可能
+
+        println!("  キャプチャ: 0/{}", cal_config.intrinsic_frames);
+
+        while all_corners.len() < cal_config.intrinsic_frames && renderer.is_open() {
+            let frame = match camera.get_frame() {
+                Some(f) => f,
+                None => continue,
+            };
+
+            // ChArUcoコーナー検出（処理に時間がかかる）
+            let (corners, ids, n_corners) = detect_charuco_corners(&detector, &frame)?;
+
+            // 自動キャプチャ
+            let captured_now = if n_corners >= 6 && last_capture.elapsed() >= capture_interval {
+                all_corners.push(corners.clone());
+                all_ids.push(ids);
+                last_capture = Instant::now();
+                println!("  キャプチャ: {}/{}", all_corners.len(), cal_config.intrinsic_frames);
+                true
+            } else {
+                false
+            };
+
+            // 検出後に最新フレームを取得して表示（遅延解消）
+            let mut display = camera.get_frame().unwrap_or(frame);
+
+            if n_corners > 0 {
+                for i in 0..n_corners {
+                    let pt = corners.at_2d::<opencv::core::Point2f>(i, 0)?;
+                    let color = if n_corners >= 6 {
+                        Scalar::new(0.0, 255.0, 0.0, 0.0)
+                    } else {
+                        Scalar::new(0.0, 255.0, 255.0, 0.0)
+                    };
+                    opencv::imgproc::circle(
+                        &mut display,
+                        opencv::core::Point::new(pt.x as i32, pt.y as i32),
+                        5, color, -1, opencv::imgproc::LINE_8, 0,
+                    )?;
+                }
+            }
+
+            // ステータス表示
+            let (status, color) = if captured_now {
+                (format!("CAPTURED! | {}/{}", all_corners.len(), cal_config.intrinsic_frames),
+                 Scalar::new(255.0, 255.0, 255.0, 0.0))
+            } else if n_corners >= 6 {
+                (format!("Corners: {} OK | {}/{}", n_corners, all_corners.len(), cal_config.intrinsic_frames),
+                 Scalar::new(0.0, 255.0, 0.0, 0.0))
+            } else if n_corners > 0 {
+                (format!("Corners: {} (need 6+) | {}/{}", n_corners, all_corners.len(), cal_config.intrinsic_frames),
+                 Scalar::new(0.0, 255.0, 255.0, 0.0))
+            } else {
+                (format!("No corners | {}/{}", all_corners.len(), cal_config.intrinsic_frames),
+                 Scalar::new(0.0, 0.0, 255.0, 0.0))
+            };
+            opencv::imgproc::put_text(
+                &mut display, &status,
+                opencv::core::Point::new(10, 30),
+                opencv::imgproc::FONT_HERSHEY_SIMPLEX, 0.7,
+                color, 2, opencv::imgproc::LINE_8, false,
+            )?;
+
+            renderer.draw_frame(&display)?;
+            renderer.update()?;
+
+            if renderer.is_key_pressed(Key::Q) {
+                bail!("ユーザーにより中止されました");
+            }
+        }
+
+        if all_corners.len() < 3 {
+            println!("  フレーム不足（{}枚、最低3枚必要）。デフォルト値を使用します", all_corners.len());
+            // デフォルトの内部パラメータ（FOV 55度相当）
+            let fy = h as f64 / (2.0 * (55.0f64.to_radians() / 2.0).tan());
+            let mut k = Mat::eye(3, 3, opencv::core::CV_64F)?.to_mat()?;
+            *k.at_2d_mut::<f64>(0, 0)? = fy;
+            *k.at_2d_mut::<f64>(1, 1)? = fy;
+            *k.at_2d_mut::<f64>(0, 2)? = w as f64 / 2.0;
+            *k.at_2d_mut::<f64>(1, 2)? = h as f64 / 2.0;
+            camera_matrices.push(k);
+            dist_coeffs_vec.push(Mat::zeros(5, 1, opencv::core::CV_64F)?.to_mat()?);
+            reprojection_errors.push(-1.0);
+        } else {
+            println!("  キャリブレーション中...");
+            let (k, dist, error) = calibrate_intrinsics(&all_corners, &all_ids, &board, image_size)?;
+            println!("  再投影誤差: {:.4} px", error);
+            camera_matrices.push(k);
+            dist_coeffs_vec.push(dist);
+            reprojection_errors.push(error);
+        }
+    }
+
+    // [3/4] 外部パラメータキャリブレーション
+    if num_cameras >= 2 {
+        println!();
+        println!("[3/4] 外部パラメータキャリブレーション");
+        println!("  全カメラからボードが見える位置にボードを置いてください");
+        println!("  全カメラで6コーナー以上検出されると自動キャプチャします");
+        println!("  [Q] 中止");
+        println!();
+
+        // 全カメラを開く + 1ウィンドウにタイル表示
+        let mut cameras: Vec<ThreadedCamera> = Vec::new();
+        let mut cam_sizes: Vec<(usize, usize)> = Vec::new();
+        for &cam_id in &camera_indices {
+            let cam = ThreadedCamera::start(cam_id, Some(1280), Some(960))?;
+            let (w, h) = cam.resolution();
+            cam_sizes.push((w as usize, h as usize));
+            cameras.push(cam);
+        }
+
+        // タイルレイアウト: 合計幅1280px以内に収める
+        let cols = if num_cameras <= 3 { num_cameras } else { 2 };
+        let rows = (num_cameras + cols - 1) / cols;
+        let max_window_w: usize = 1280;
+        let raw_w = cam_sizes[0].0 * cols;
+        let scale = if raw_w > max_window_w {
+            max_window_w as f64 / raw_w as f64
+        } else {
+            1.0
+        };
+        let tile_w = (cam_sizes[0].0 as f64 * scale) as usize;
+        let tile_h = (cam_sizes[0].1 as f64 * scale) as usize;
+        let combined_w = tile_w * cols;
+        let combined_h = tile_h * rows;
+
+        let mut renderer = MinifbRenderer::new(
+            "Calibrate - All Cameras",
+            combined_w,
+            combined_h,
+        )?;
+
+        // 歪み補正済み画像で検出するため、solvePnPには歪み=0を渡す
+        let zero_dist = Mat::zeros(5, 1, opencv::core::CV_64F)?.to_mat()?;
+
+        let mut extrinsic_done = false;
+        let mut all_poses: Vec<(Mat, Mat)> = Vec::new();
+
+        while !extrinsic_done && renderer.is_open() {
+            // 全カメラからフレーム取得・検出・表示
+            let mut frames: Vec<Mat> = Vec::new();
+            let mut corner_data: Vec<(Mat, Mat, i32)> = Vec::new();
+
+            for (i, cam) in cameras.iter().enumerate() {
+                let frame = match cam.get_frame() {
+                    Some(f) => f,
+                    None => {
+                        frames.push(Mat::default());
+                        corner_data.push((Mat::default(), Mat::default(), 0));
+                        continue;
+                    }
+                };
+
+                // 歪み補正してから検出（広角カメラ対応）
+                let mut undistorted = Mat::default();
+                calib3d::undistort(
+                    &frame, &mut undistorted,
+                    &camera_matrices[i], &dist_coeffs_vec[i],
+                    &camera_matrices[i],
+                )?;
+
+                let (corners, ids, n) = detect_charuco_corners(&detector, &undistorted)?;
+
+                // 表示は生画像（検出のみundistort）
+                let mut display = cam.get_frame().unwrap_or(frame.clone());
+
+                if n > 0 {
+                    for j in 0..n {
+                        let pt = corners.at_2d::<opencv::core::Point2f>(j, 0)?;
+                        let color = if n >= 6 {
+                            Scalar::new(0.0, 255.0, 0.0, 0.0)
+                        } else {
+                            Scalar::new(0.0, 255.0, 255.0, 0.0)
+                        };
+                        opencv::imgproc::circle(
+                            &mut display,
+                            opencv::core::Point::new(pt.x as i32, pt.y as i32),
+                            5, color, -1, opencv::imgproc::LINE_8, 0,
+                        )?;
+                    }
+                }
+
+                let (status, color) = if n >= 6 {
+                    (format!("Cam {} | Corners: {}", camera_indices[i], n),
+                     Scalar::new(0.0, 255.0, 0.0, 0.0))
+                } else if n > 0 {
+                    (format!("Cam {} | Corners: {} (need 6+)", camera_indices[i], n),
+                     Scalar::new(0.0, 255.0, 255.0, 0.0))
+                } else {
+                    (format!("Cam {} | No corners", camera_indices[i]),
+                     Scalar::new(0.0, 0.0, 255.0, 0.0))
+                };
+                opencv::imgproc::put_text(
+                    &mut display, &status,
+                    opencv::core::Point::new(10, 30),
+                    opencv::imgproc::FONT_HERSHEY_SIMPLEX, 0.7,
+                    color, 2, opencv::imgproc::LINE_8, false,
+                )?;
+
+                // カメラ解像度がタイルサイズと異なる場合はリサイズ
+                let display_final = if display.cols() as usize != tile_w || display.rows() as usize != tile_h {
+                    let mut resized = Mat::default();
+                    opencv::imgproc::resize(
+                        &display, &mut resized,
+                        Size::new(tile_w as i32, tile_h as i32),
+                        0.0, 0.0, opencv::imgproc::INTER_LINEAR,
+                    )?;
+                    resized
+                } else {
+                    display
+                };
+
+                let col = i % cols;
+                let row = i / cols;
+                renderer.draw_frame_at(&display_final, col * tile_w, row * tile_h)?;
+
+                frames.push(frame);
+                corner_data.push((corners, ids, n));
+            }
+
+            renderer.update()?;
+
+            // 全カメラでコーナーが十分なら自動キャプチャ
+            let all_have_enough = corner_data.iter().all(|(_, _, n)| *n >= 6);
+
+            if all_have_enough {
+                all_poses.clear();
+                let mut all_valid = true;
+
+                for (i, (corners, ids, _)) in corner_data.iter().enumerate() {
+                    match estimate_pose(
+                        corners, ids, &board,
+                        &camera_matrices[i], &zero_dist,
+                    )? {
+                        Some((rvec, tvec)) => {
+                            all_poses.push((rvec, tvec));
+                        }
+                        None => {
+                            println!("  カメラ{}: ポーズ推定失敗", camera_indices[i]);
+                            all_valid = false;
+                            break;
+                        }
+                    }
+                }
+
+                if all_valid && all_poses.len() == num_cameras {
+                    println!("  全カメラでポーズ推定成功！");
+                    extrinsic_done = true;
+                }
+            }
+
+            if renderer.is_key_pressed(Key::Q) {
+                bail!("ユーザーにより中止されました");
+            }
+        }
+
+        if !extrinsic_done {
+            bail!("外部パラメータキャリブレーションが完了しませんでした");
+        }
+
+        // 相対ポーズ計算
+        let relative_poses = compute_relative_poses(&all_poses)?;
+
+        // [4/4] 保存
+        println!();
+        println!("[4/4] キャリブレーション結果を保存中...");
+
+        let mut camera_cals = Vec::new();
+        for (i, &cam_id) in camera_indices.iter().enumerate() {
+            let (rv, tv) = &relative_poses[i];
+            let intrinsic = mat3x3_to_array(&camera_matrices[i])?;
+            let dist = mat_to_vec(&dist_coeffs_vec[i])?;
+
+            camera_cals.push(CameraCalibration {
+                camera_index: cam_id,
+                width: image_sizes[i].width as u32,
+                height: image_sizes[i].height as u32,
+                intrinsic_matrix: intrinsic,
+                dist_coeffs: dist,
+                rvec: *rv,
+                tvec: *tv,
+                reprojection_error: reprojection_errors[i],
+            });
+        }
+
+        let result = MultiCameraCalibration {
+            board: BoardParams {
+                dictionary: cal_config.dictionary.clone(),
+                squares_x: cal_config.squares_x,
+                squares_y: cal_config.squares_y,
+                square_length: cal_config.square_length,
+                marker_length: cal_config.marker_length,
+            },
+            cameras: camera_cals,
+        };
+
+        save_calibration(&cal_config.output_path, &result)?;
+        println!("保存完了: {}", cal_config.output_path);
+    } else {
+        // 単一カメラ: 内部パラメータのみ保存
+        println!();
+        println!("[3/4] 単一カメラのため外部パラメータキャリブレーションをスキップ");
+        println!();
+        println!("[4/4] キャリブレーション結果を保存中...");
+
+        let intrinsic = mat3x3_to_array(&camera_matrices[0])?;
+        let dist = mat_to_vec(&dist_coeffs_vec[0])?;
+
+        let result = MultiCameraCalibration {
+            board: BoardParams {
+                dictionary: cal_config.dictionary.clone(),
+                squares_x: cal_config.squares_x,
+                squares_y: cal_config.squares_y,
+                square_length: cal_config.square_length,
+                marker_length: cal_config.marker_length,
+            },
+            cameras: vec![CameraCalibration {
+                camera_index: camera_indices[0],
+                width: image_sizes[0].width as u32,
+                height: image_sizes[0].height as u32,
+                intrinsic_matrix: intrinsic,
+                dist_coeffs: dist,
+                rvec: [0.0, 0.0, 0.0],
+                tvec: [0.0, 0.0, 0.0],
+                reprojection_error: reprojection_errors[0],
+            }],
+        };
+
+        save_calibration(&cal_config.output_path, &result)?;
+        println!("保存完了: {}", cal_config.output_path);
+    }
+
+    println!();
+    println!("=== キャリブレーション完了 ===");
+    Ok(())
+}

--- a/src/bin/generate_board.rs
+++ b/src/bin/generate_board.rs
@@ -1,0 +1,152 @@
+use anyhow::Result;
+use opencv::core::{Mat, Point, Scalar, Size};
+use opencv::imgcodecs;
+use opencv::imgproc;
+use opencv::prelude::*;
+
+use talava_tracker::calibration::create_board;
+use talava_tracker::config::Config;
+
+const CONFIG_PATH: &str = "config.toml";
+
+fn main() -> Result<()> {
+    let config = Config::load(CONFIG_PATH)?;
+    let cal = &config.calibration;
+
+    let board = create_board(cal)?;
+
+    // ボード画像生成（余白なし）
+    let board_margin = 0;
+    let border_bits = 1;
+
+    // マス1辺のピクセルサイズを決めてボードサイズを算出
+    let px_per_square = 120;
+    let board_w = cal.squares_x * px_per_square;
+    let board_h = cal.squares_y * px_per_square;
+    let board_size = Size::new(board_w, board_h);
+
+    let mut board_img = Mat::default();
+    board.generate_image(board_size, &mut board_img, board_margin, border_bits)?;
+
+    // ルーラー領域のサイズ
+    let ruler_h = 80; // 下部ルーラー高さ
+    let ruler_w = 60; // 左部ルーラー幅
+    let pad = 20; // ボード周囲の余白
+    let text_h = 40; // 下部テキスト高さ
+
+    let total_w = ruler_w + pad + board_w + pad;
+    let total_h = pad + board_h + pad + ruler_h + text_h;
+
+    // 白背景キャンバス
+    let mut canvas = Mat::new_rows_cols_with_default(total_h, total_w, opencv::core::CV_8UC1, Scalar::all(255.0))?;
+
+    // ボード画像をキャンバスに配置
+    let board_x = ruler_w + pad;
+    let board_y = pad;
+    let mut roi = Mat::roi_mut(
+        &mut canvas,
+        opencv::core::Rect::new(board_x, board_y, board_w, board_h),
+    )?;
+    board_img.copy_to(&mut roi)?;
+
+    // --- 下部ルーラー（横方向、マス幅を計測用） ---
+    let ruler_y_start = board_y + board_h + pad;
+    let ruler_y_end = ruler_y_start + 30;
+    let black = Scalar::all(0.0);
+    // ルーラーベースライン
+    imgproc::line(
+        &mut canvas,
+        Point::new(board_x, ruler_y_start),
+        Point::new(board_x + board_w, ruler_y_start),
+        black, 2, imgproc::LINE_8, 0,
+    )?;
+
+    // マスごとの目盛り
+    for i in 0..=cal.squares_x {
+        let x = board_x + i * px_per_square;
+        let tick_len = 20;
+        imgproc::line(
+            &mut canvas,
+            Point::new(x, ruler_y_start),
+            Point::new(x, ruler_y_start + tick_len),
+            black, 2, imgproc::LINE_8, 0,
+        )?;
+
+        // 数字ラベル
+        imgproc::put_text(
+            &mut canvas,
+            &format!("{}", i),
+            Point::new(x - 5, ruler_y_start + tick_len + 18),
+            imgproc::FONT_HERSHEY_SIMPLEX, 0.5, black, 1, imgproc::LINE_8, false,
+        )?;
+    }
+
+    // "1 square" 矢印範囲
+    let arrow_y = ruler_y_end + 22;
+    let arr_x0 = board_x;
+    let arr_x1 = board_x + px_per_square;
+    imgproc::arrowed_line(
+        &mut canvas,
+        Point::new(arr_x0, arrow_y),
+        Point::new(arr_x1 - 2, arrow_y),
+        black, 1, imgproc::LINE_8, 0, 0.15,
+    )?;
+    imgproc::arrowed_line(
+        &mut canvas,
+        Point::new(arr_x1, arrow_y),
+        Point::new(arr_x0 + 2, arrow_y),
+        black, 1, imgproc::LINE_8, 0, 0.15,
+    )?;
+
+    // 説明テキスト
+    let text_y = ruler_y_end + 55;
+    imgproc::put_text(
+        &mut canvas,
+        "measure 1 square -> config.toml square_length (m)",
+        Point::new(board_x, text_y),
+        imgproc::FONT_HERSHEY_SIMPLEX, 0.5, black, 1, imgproc::LINE_8, false,
+    )?;
+
+    // --- 左部ルーラー（縦方向） ---
+    let ruler_x_start = ruler_w - 5;
+
+    // ベースライン
+    imgproc::line(
+        &mut canvas,
+        Point::new(ruler_x_start, board_y),
+        Point::new(ruler_x_start, board_y + board_h),
+        black, 2, imgproc::LINE_8, 0,
+    )?;
+
+    // マスごとの目盛り
+    for i in 0..=cal.squares_y {
+        let y = board_y + i * px_per_square;
+        let tick_len = 15;
+        imgproc::line(
+            &mut canvas,
+            Point::new(ruler_x_start - tick_len, y),
+            Point::new(ruler_x_start, y),
+            black, 2, imgproc::LINE_8, 0,
+        )?;
+
+        imgproc::put_text(
+            &mut canvas,
+            &format!("{}", i),
+            Point::new(ruler_x_start - tick_len - 18, y + 5),
+            imgproc::FONT_HERSHEY_SIMPLEX, 0.5, black, 1, imgproc::LINE_8, false,
+        )?;
+    }
+
+    let filename = format!(
+        "charuco_{}x{}_{}.png",
+        cal.squares_x, cal.squares_y, cal.dictionary
+    );
+    imgcodecs::imwrite(&filename, &canvas, &opencv::core::Vector::new())?;
+    println!("保存: {}", filename);
+    println!("  マス数: {}x{}", cal.squares_x, cal.squares_y);
+    println!("  辞書: {}", cal.dictionary);
+    println!("  モニターに表示し、1マスの幅を物理的に測ってconfig.tomlのsquare_lengthに入力");
+    println!("  marker_length = square_length * 0.75 が目安");
+
+    Ok(())
+}

--- a/src/calibration.rs
+++ b/src/calibration.rs
@@ -1,0 +1,407 @@
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use std::fs;
+
+use opencv::{
+    calib3d,
+    core::{Mat, Size, TermCriteria, TermCriteria_Type, Vector},
+    objdetect::{
+        self, CharucoBoard, CharucoDetector, Dictionary,
+        PredefinedDictionaryType,
+    },
+    prelude::*,
+};
+
+use crate::config::CalibrationConfig;
+
+// --- データ構造 ---
+
+/// ボードパラメータ（再現用に保存）
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BoardParams {
+    pub dictionary: String,
+    pub squares_x: i32,
+    pub squares_y: i32,
+    pub square_length: f32,
+    pub marker_length: f32,
+}
+
+/// 単一カメラのキャリブレーション結果
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CameraCalibration {
+    pub camera_index: i32,
+    pub width: u32,
+    pub height: u32,
+    /// 内部パラメータ行列 K (row-major 3x3)
+    pub intrinsic_matrix: [f64; 9],
+    /// 歪み係数
+    pub dist_coeffs: Vec<f64>,
+    /// 回転ベクトル (Rodrigues)
+    pub rvec: [f64; 3],
+    /// 並進ベクトル
+    pub tvec: [f64; 3],
+    /// 再投影誤差
+    pub reprojection_error: f64,
+}
+
+/// マルチカメラキャリブレーション結果
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MultiCameraCalibration {
+    pub board: BoardParams,
+    pub cameras: Vec<CameraCalibration>,
+}
+
+// --- Save / Load ---
+
+pub fn save_calibration(path: &str, cal: &MultiCameraCalibration) -> Result<()> {
+    let json = serde_json::to_string_pretty(cal)?;
+    fs::write(path, json).context("Failed to write calibration file")?;
+    Ok(())
+}
+
+pub fn load_calibration(path: &str) -> Result<MultiCameraCalibration> {
+    let content = fs::read_to_string(path).context("Failed to read calibration file")?;
+    let cal: MultiCameraCalibration = serde_json::from_str(&content)?;
+    Ok(cal)
+}
+
+// --- 辞書ヘルパー ---
+
+pub fn parse_dictionary(name: &str) -> Result<Dictionary> {
+    let dict_type = match name {
+        "DICT_4X4_50" => PredefinedDictionaryType::DICT_4X4_50,
+        "DICT_4X4_100" => PredefinedDictionaryType::DICT_4X4_100,
+        "DICT_4X4_250" => PredefinedDictionaryType::DICT_4X4_250,
+        "DICT_4X4_1000" => PredefinedDictionaryType::DICT_4X4_1000,
+        "DICT_5X5_50" => PredefinedDictionaryType::DICT_5X5_50,
+        "DICT_5X5_100" => PredefinedDictionaryType::DICT_5X5_100,
+        "DICT_5X5_250" => PredefinedDictionaryType::DICT_5X5_250,
+        "DICT_5X5_1000" => PredefinedDictionaryType::DICT_5X5_1000,
+        "DICT_6X6_50" => PredefinedDictionaryType::DICT_6X6_50,
+        "DICT_6X6_100" => PredefinedDictionaryType::DICT_6X6_100,
+        "DICT_6X6_250" => PredefinedDictionaryType::DICT_6X6_250,
+        "DICT_6X6_1000" => PredefinedDictionaryType::DICT_6X6_1000,
+        _ => bail!("Unknown dictionary: {}", name),
+    };
+    objdetect::get_predefined_dictionary(dict_type).context("Failed to get predefined dictionary")
+}
+
+/// ChArUcoボードを作成
+pub fn create_board(config: &CalibrationConfig) -> Result<CharucoBoard> {
+    let dict = parse_dictionary(&config.dictionary)?;
+    let size = Size::new(config.squares_x, config.squares_y);
+    CharucoBoard::new_def(size, config.square_length, config.marker_length, &dict)
+        .context("Failed to create CharucoBoard")
+}
+
+/// ChArUcoDetectorを作成（広角・斜め検出対応）
+pub fn create_detector(board: &CharucoBoard) -> Result<CharucoDetector> {
+    use objdetect::{CharucoParameters, DetectorParameters, DetectorParametersTrait, RefineParameters};
+
+    let mut det_params = DetectorParameters::default()?;
+    // 歪んだ四角形をより寛容に受け入れる（デフォルト0.03）
+    det_params.set_polygonal_approx_accuracy_rate(0.08);
+    // パースペクティブ補正の解像度を上げる（デフォルト4）
+    det_params.set_perspective_remove_pixel_per_cell(8);
+    // 適応的閾値の探索範囲を広げる（デフォルト max=23）
+    det_params.set_adaptive_thresh_win_size_max(53);
+
+    let charuco_params = CharucoParameters::default()?;
+    let refine_params = RefineParameters::new(10.0, 3.0, true)?;
+
+    CharucoDetector::new(board, &charuco_params, &det_params, refine_params)
+        .context("Failed to create CharucoDetector")
+}
+
+// --- 内部パラメータキャリブレーション ---
+
+/// 1フレームからChArUcoコーナーを検出
+///
+/// 戻り値: (corners, ids, corner_count)
+/// corner_countが0の場合もcornersとidsは空のMatが返る。
+pub fn detect_charuco_corners(
+    detector: &CharucoDetector,
+    image: &Mat,
+) -> Result<(Mat, Mat, i32)> {
+    let mut corners = Mat::default();
+    let mut ids = Mat::default();
+
+    detector
+        .detect_board_def(image, &mut corners, &mut ids)
+        .context("detect_board failed")?;
+
+    let n = ids.rows();
+    Ok((corners, ids, n))
+}
+
+/// 蓄積されたコーナーから内部パラメータをキャリブレーション
+///
+/// - all_corners: 各フレームのChArUcoコーナー座標
+/// - all_ids: 各フレームのChArUcoコーナーID
+/// - board: ChArUcoボード
+/// - image_size: 画像サイズ
+///
+/// 戻り値: (camera_matrix, dist_coeffs, reprojection_error)
+pub fn calibrate_intrinsics(
+    all_corners: &[Mat],
+    all_ids: &[Mat],
+    board: &CharucoBoard,
+    image_size: Size,
+) -> Result<(Mat, Mat, f64)> {
+    if all_corners.is_empty() {
+        bail!("No calibration frames provided");
+    }
+
+    // match_image_points で 3D-2D 対応を構築
+    let mut all_obj_points = Vector::<Mat>::new();
+    let mut all_img_points = Vector::<Mat>::new();
+
+    for i in 0..all_corners.len() {
+        let mut obj_pts = Mat::default();
+        let mut img_pts = Mat::default();
+        board
+            .match_image_points(&all_corners[i], &all_ids[i], &mut obj_pts, &mut img_pts)
+            .context("match_image_points failed")?;
+
+        if obj_pts.rows() >= 6 {
+            all_obj_points.push(obj_pts);
+            all_img_points.push(img_pts);
+        }
+    }
+
+    if all_obj_points.len() < 3 {
+        bail!(
+            "Not enough valid frames for calibration (got {}, need >= 3)",
+            all_obj_points.len()
+        );
+    }
+
+    let mut camera_matrix = Mat::default();
+    let mut dist_coeffs = Mat::default();
+    let mut rvecs = Mat::default();
+    let mut tvecs = Mat::default();
+
+    let criteria = TermCriteria::new(
+        TermCriteria_Type::COUNT as i32 + TermCriteria_Type::EPS as i32,
+        100,
+        1e-6,
+    )?;
+
+    let error = calib3d::calibrate_camera(
+        &all_obj_points,
+        &all_img_points,
+        image_size,
+        &mut camera_matrix,
+        &mut dist_coeffs,
+        &mut rvecs,
+        &mut tvecs,
+        calib3d::CALIB_FIX_ASPECT_RATIO,
+        criteria,
+    )
+    .context("calibrate_camera failed")?;
+
+    // fx/fy比のバリデーション
+    let fx = *camera_matrix.at_2d::<f64>(0, 0)?;
+    let fy = *camera_matrix.at_2d::<f64>(1, 1)?;
+    if fy.abs() > 1e-10 {
+        let ratio = fx / fy;
+        if ratio < 0.9 || ratio > 1.1 {
+            bail!(
+                "Calibration produced abnormal fx/fy ratio: {:.3} (fx={:.1}, fy={:.1}). \
+                 This indicates poor calibration input. Try capturing more diverse board angles.",
+                ratio, fx, fy,
+            );
+        }
+    }
+
+    Ok((camera_matrix, dist_coeffs, error))
+}
+
+// --- 外部パラメータキャリブレーション ---
+
+/// 1フレームからsolvePnPで外部パラメータを推定
+///
+/// 戻り値: (rvec, tvec)
+pub fn estimate_pose(
+    corners: &Mat,
+    ids: &Mat,
+    board: &CharucoBoard,
+    camera_matrix: &Mat,
+    dist_coeffs: &Mat,
+) -> Result<Option<(Mat, Mat)>> {
+    let mut obj_pts = Mat::default();
+    let mut img_pts = Mat::default();
+    board
+        .match_image_points(corners, ids, &mut obj_pts, &mut img_pts)
+        .context("match_image_points failed")?;
+
+    if obj_pts.rows() < 6 {
+        return Ok(None);
+    }
+
+    let mut rvec = Mat::default();
+    let mut tvec = Mat::default();
+
+    let ok = calib3d::solve_pnp(
+        &obj_pts,
+        &img_pts,
+        camera_matrix,
+        dist_coeffs,
+        &mut rvec,
+        &mut tvec,
+        false,
+        calib3d::SOLVEPNP_ITERATIVE,
+    )
+    .context("solvePnP failed")?;
+
+    if !ok {
+        return Ok(None);
+    }
+
+    Ok(Some((rvec, tvec)))
+}
+
+/// カメラ0を原点として相対変換を計算
+///
+/// 入力: 各カメラの (rvec, tvec) — ボード座標系→カメラ座標系
+/// 出力: 各カメラの (rvec, tvec) — カメラ0座標系基準
+pub fn compute_relative_poses(
+    poses: &[(Mat, Mat)],
+) -> Result<Vec<([f64; 3], [f64; 3])>> {
+    if poses.is_empty() {
+        bail!("No poses provided");
+    }
+
+    /// rvec(Mat 3x1) → 回転行列 [[f64;3];3]
+    fn rvec_to_rmat(rvec: &Mat) -> Result<[[f64; 3]; 3]> {
+        let mut rmat = Mat::default();
+        let mut jacobian = Mat::default();
+        calib3d::rodrigues(rvec, &mut rmat, &mut jacobian)
+            .context("Rodrigues failed")?;
+        let mut r = [[0.0f64; 3]; 3];
+        for row in 0..3 {
+            for col in 0..3 {
+                r[row][col] = *rmat.at_2d::<f64>(row as i32, col as i32)?;
+            }
+        }
+        Ok(r)
+    }
+
+    /// tvec(Mat 3x1 or 1x3) → [f64;3]
+    fn mat_to_vec3(m: &Mat) -> Result<[f64; 3]> {
+        if m.rows() == 1 {
+            Ok([*m.at_2d::<f64>(0, 0)?, *m.at_2d::<f64>(0, 1)?, *m.at_2d::<f64>(0, 2)?])
+        } else {
+            Ok([*m.at_2d::<f64>(0, 0)?, *m.at_2d::<f64>(1, 0)?, *m.at_2d::<f64>(2, 0)?])
+        }
+    }
+
+    /// 回転行列 → rvec [f64;3]
+    fn rmat_to_rvec(r: &[[f64; 3]; 3]) -> Result<[f64; 3]> {
+        let mut rmat = Mat::zeros(3, 3, opencv::core::CV_64F)?.to_mat()?;
+        for row in 0..3 {
+            for col in 0..3 {
+                *rmat.at_2d_mut::<f64>(row as i32, col as i32)? = r[row][col];
+            }
+        }
+        let mut rvec = Mat::default();
+        let mut jacobian = Mat::default();
+        calib3d::rodrigues(&rmat, &mut rvec, &mut jacobian)
+            .context("Rodrigues failed")?;
+        if rvec.rows() == 1 {
+            Ok([*rvec.at_2d::<f64>(0, 0)?, *rvec.at_2d::<f64>(0, 1)?, *rvec.at_2d::<f64>(0, 2)?])
+        } else {
+            Ok([*rvec.at_2d::<f64>(0, 0)?, *rvec.at_2d::<f64>(1, 0)?, *rvec.at_2d::<f64>(2, 0)?])
+        }
+    }
+
+    fn mul_3x3(a: &[[f64; 3]; 3], b: &[[f64; 3]; 3]) -> [[f64; 3]; 3] {
+        let mut c = [[0.0f64; 3]; 3];
+        for i in 0..3 {
+            for j in 0..3 {
+                for k in 0..3 {
+                    c[i][j] += a[i][k] * b[k][j];
+                }
+            }
+        }
+        c
+    }
+
+    fn mul_3x3_vec(m: &[[f64; 3]; 3], v: &[f64; 3]) -> [f64; 3] {
+        [
+            m[0][0] * v[0] + m[0][1] * v[1] + m[0][2] * v[2],
+            m[1][0] * v[0] + m[1][1] * v[1] + m[1][2] * v[2],
+            m[2][0] * v[0] + m[2][1] * v[1] + m[2][2] * v[2],
+        ]
+    }
+
+    fn transpose(m: &[[f64; 3]; 3]) -> [[f64; 3]; 3] {
+        [
+            [m[0][0], m[1][0], m[2][0]],
+            [m[0][1], m[1][1], m[2][1]],
+            [m[0][2], m[1][2], m[2][2]],
+        ]
+    }
+
+    let r0 = rvec_to_rmat(&poses[0].0)?;
+    let t0 = mat_to_vec3(&poses[0].1)?;
+    let r0_t = transpose(&r0);
+
+    let mut results = Vec::new();
+
+    for (i, (rvec, tvec)) in poses.iter().enumerate() {
+        if i == 0 {
+            results.push(([0.0, 0.0, 0.0], [0.0, 0.0, 0.0]));
+            continue;
+        }
+
+        let ri = rvec_to_rmat(rvec)?;
+        let ti = mat_to_vec3(tvec)?;
+
+        // R_rel = R_i * R_0^T
+        let r_rel = mul_3x3(&ri, &r0_t);
+
+        // t_rel = t_i - R_rel * t_0
+        let rt0 = mul_3x3_vec(&r_rel, &t0);
+        let t_rel = [ti[0] - rt0[0], ti[1] - rt0[1], ti[2] - rt0[2]];
+
+        // R_rel → rvec
+        let rv = rmat_to_rvec(&r_rel)?;
+
+        results.push((rv, t_rel));
+    }
+
+    Ok(results)
+}
+
+// --- Mat ↔ 配列変換ヘルパー ---
+
+/// 3x3 Mat (f64) → [f64; 9] row-major
+pub fn mat3x3_to_array(mat: &Mat) -> Result<[f64; 9]> {
+    if mat.rows() != 3 || mat.cols() != 3 {
+        bail!("Expected 3x3 matrix, got {}x{}", mat.rows(), mat.cols());
+    }
+    let mut arr = [0.0f64; 9];
+    for r in 0..3 {
+        for c in 0..3 {
+            arr[r * 3 + c] = *mat.at_2d::<f64>(r as i32, c as i32)?;
+        }
+    }
+    Ok(arr)
+}
+
+/// Vec<f64> from Mat (Nx1 or 1xN)
+pub fn mat_to_vec(mat: &Mat) -> Result<Vec<f64>> {
+    let n = mat.rows().max(mat.cols()) as usize;
+    let mut v = Vec::with_capacity(n);
+    let is_row = mat.rows() == 1;
+    for i in 0..n {
+        let val = if is_row {
+            *mat.at_2d::<f64>(0, i as i32)?
+        } else {
+            *mat.at_2d::<f64>(i as i32, 0)?
+        };
+        v.push(val);
+    }
+    Ok(v)
+}

--- a/src/camera/capture.rs
+++ b/src/camera/capture.rs
@@ -1,0 +1,171 @@
+use anyhow::{Context, Result};
+use opencv::{
+    core::Mat,
+    prelude::*,
+    videoio::{self, VideoCapture, VideoCaptureAPIs, VideoCaptureTrait},
+};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+/// 利用可能なカメラを検出する
+///
+/// index 0から順に試し、開けなくなったら停止する。
+/// AVFoundationではindexが連続しているため、最初の失敗で打ち切り。
+pub fn detect_cameras(max_probe: i32) -> Vec<i32> {
+    let mut found = Vec::new();
+    for i in 0..max_probe {
+        match VideoCapture::new(i, VideoCaptureAPIs::CAP_AVFOUNDATION as i32) {
+            Ok(cap) => {
+                if cap.is_opened().unwrap_or(false) {
+                    found.push(i);
+                } else {
+                    break;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+    found
+}
+
+/// OpenCVを使用したカメラキャプチャ
+pub struct OpenCvCamera {
+    capture: VideoCapture,
+    width: u32,
+    height: u32,
+}
+
+impl OpenCvCamera {
+    /// カメラを開く（デフォルトカメラ: index 0）
+    pub fn open(index: i32) -> Result<Self> {
+        Self::open_with_resolution(index, None, None)
+    }
+
+    /// 解像度とFPSを指定してカメラを開く
+    pub fn open_with_resolution(index: i32, width: Option<u32>, height: Option<u32>) -> Result<Self> {
+        Self::open_with_config(index, width, height, Some(60))
+    }
+
+    /// 解像度とFPSを指定してカメラを開く
+    pub fn open_with_config(index: i32, width: Option<u32>, height: Option<u32>, fps: Option<u32>) -> Result<Self> {
+        let mut capture =
+            VideoCapture::new(index, VideoCaptureAPIs::CAP_AVFOUNDATION as i32).context("Failed to open camera")?;
+
+        if !capture.is_opened()? {
+            anyhow::bail!("Camera {} is not available", index);
+        }
+
+        // 解像度を設定
+        if let Some(w) = width {
+            capture.set(videoio::CAP_PROP_FRAME_WIDTH, w as f64)?;
+        }
+        if let Some(h) = height {
+            capture.set(videoio::CAP_PROP_FRAME_HEIGHT, h as f64)?;
+        }
+        if let Some(f) = fps {
+            capture.set(videoio::CAP_PROP_FPS, f as f64)?;
+        }
+        capture.set(videoio::CAP_PROP_BUFFERSIZE, 1.0)?;
+
+        let actual_width = capture.get(videoio::CAP_PROP_FRAME_WIDTH)? as u32;
+        let actual_height = capture.get(videoio::CAP_PROP_FRAME_HEIGHT)? as u32;
+        let actual_fps = capture.get(videoio::CAP_PROP_FPS)?;
+        println!("Camera FPS: {}", actual_fps);
+
+        Ok(Self {
+            capture,
+            width: actual_width,
+            height: actual_height,
+        })
+    }
+
+    /// 解像度を取得
+    pub fn resolution(&self) -> (u32, u32) {
+        (self.width, self.height)
+    }
+
+    /// フレームを読み込む（BGR形式）
+    pub fn read_frame(&mut self) -> Result<Mat> {
+        let mut frame = Mat::default();
+        self.capture
+            .read(&mut frame)
+            .context("Failed to read frame")?;
+
+        if frame.empty() {
+            anyhow::bail!("Empty frame received");
+        }
+
+        Ok(frame)
+    }
+}
+
+/// 別スレッドでカメラキャプチャを行い、最新フレームを提供する
+pub struct ThreadedCamera {
+    latest: Arc<Mutex<Option<Mat>>>,
+    frame_id: Arc<AtomicU64>,
+    running: Arc<AtomicBool>,
+    width: u32,
+    height: u32,
+    _handle: Option<thread::JoinHandle<()>>,
+}
+
+impl Drop for ThreadedCamera {
+    fn drop(&mut self) {
+        self.running.store(false, Ordering::Release);
+        if let Some(handle) = self._handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+impl ThreadedCamera {
+    pub fn start(index: i32, width: Option<u32>, height: Option<u32>) -> Result<Self> {
+        let mut camera = OpenCvCamera::open_with_resolution(index, width, height)?;
+        let (w, h) = camera.resolution();
+        let latest = Arc::new(Mutex::new(None::<Mat>));
+        let latest_ref = latest.clone();
+        let frame_id = Arc::new(AtomicU64::new(0));
+        let frame_id_ref = frame_id.clone();
+        let running = Arc::new(AtomicBool::new(true));
+        let running_ref = running.clone();
+
+        let handle = thread::spawn(move || {
+            while running_ref.load(Ordering::Acquire) {
+                match camera.read_frame() {
+                    Ok(frame) => {
+                        *latest_ref.lock().unwrap() = Some(frame);
+                        frame_id_ref.fetch_add(1, Ordering::Release);
+                    }
+                    Err(_) => {}
+                }
+            }
+        });
+
+        Ok(Self {
+            latest,
+            frame_id,
+            running,
+            width: w,
+            height: h,
+            _handle: Some(handle),
+        })
+    }
+
+    pub fn resolution(&self) -> (u32, u32) {
+        (self.width, self.height)
+    }
+
+    /// 現在のフレームIDを取得。新フレームが到着するたびにインクリメントされる。
+    pub fn frame_id(&self) -> u64 {
+        self.frame_id.load(Ordering::Acquire)
+    }
+
+    /// 最新フレームを取得。フレームは保持されるので何度でも取得可能。
+    /// カメラスレッドが新フレームを書き込むまで同じフレームが返る。
+    /// 初回フレーム到着前のみNone。
+    pub fn get_frame(&self) -> Option<Mat> {
+        let guard = self.latest.lock().unwrap();
+        guard.as_ref().map(|m| m.clone())
+    }
+}

--- a/src/camera/mod.rs
+++ b/src/camera/mod.rs
@@ -1,0 +1,5 @@
+pub mod capture;
+
+pub use capture::OpenCvCamera;
+pub use capture::ThreadedCamera;
+pub use capture::detect_cameras;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,65 @@
+use anyhow::Result;
+use serde::Deserialize;
+use std::fs;
+use std::path::Path;
+
+#[derive(Debug, Deserialize)]
+pub struct Config {
+    #[serde(default)]
+    pub calibration: CalibrationConfig,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct CalibrationConfig {
+    /// ChArUco辞書タイプ (e.g. "DICT_4X4_50")
+    #[serde(default = "default_dictionary")]
+    pub dictionary: String,
+    /// 横マス数
+    #[serde(default = "default_squares_x")]
+    pub squares_x: i32,
+    /// 縦マス数
+    #[serde(default = "default_squares_y")]
+    pub squares_y: i32,
+    /// マス辺長（メートル）
+    #[serde(default = "default_square_length")]
+    pub square_length: f32,
+    /// マーカー辺長（メートル）
+    #[serde(default = "default_marker_length")]
+    pub marker_length: f32,
+    /// 保存先パス
+    #[serde(default = "default_calibration_output")]
+    pub output_path: String,
+    /// 内部パラメータ用キャプチャフレーム数
+    #[serde(default = "default_intrinsic_frames")]
+    pub intrinsic_frames: usize,
+}
+
+fn default_dictionary() -> String { "DICT_4X4_50".to_string() }
+fn default_squares_x() -> i32 { 5 }
+fn default_squares_y() -> i32 { 4 }
+fn default_square_length() -> f32 { 0.04 }
+fn default_marker_length() -> f32 { 0.03 }
+fn default_calibration_output() -> String { "calibration.json".to_string() }
+fn default_intrinsic_frames() -> usize { 15 }
+
+impl Default for CalibrationConfig {
+    fn default() -> Self {
+        Self {
+            dictionary: default_dictionary(),
+            squares_x: default_squares_x(),
+            squares_y: default_squares_y(),
+            square_length: default_square_length(),
+            marker_length: default_marker_length(),
+            output_path: default_calibration_output(),
+            intrinsic_frames: default_intrinsic_frames(),
+        }
+    }
+}
+
+impl Config {
+    pub fn load<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let content = fs::read_to_string(path)?;
+        let config: Config = toml::from_str(&content)?;
+        Ok(config)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,11 @@
+#[cfg(feature = "imgproc")]
+pub mod calibration;
+#[cfg(feature = "imgproc")]
+pub mod camera;
+pub mod config;
 pub mod pose;
 pub mod protocol;
+#[cfg(feature = "imgproc")]
+pub mod render;
 pub mod triangulation;
 pub mod vmt;

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1,0 +1,6 @@
+pub mod skeleton;
+pub mod window;
+
+pub use skeleton::SKELETON_CONNECTIONS;
+pub use minifb::Key;
+pub use window::MinifbRenderer;

--- a/src/render/skeleton.rs
+++ b/src/render/skeleton.rs
@@ -1,0 +1,34 @@
+use crate::pose::KeypointIndex;
+
+/// 骨格の接続定義 (開始キーポイント, 終了キーポイント)
+pub const SKELETON_CONNECTIONS: [(KeypointIndex, KeypointIndex); 16] = [
+    // 顔
+    (KeypointIndex::LeftEar, KeypointIndex::LeftEye),
+    (KeypointIndex::LeftEye, KeypointIndex::Nose),
+    (KeypointIndex::Nose, KeypointIndex::RightEye),
+    (KeypointIndex::RightEye, KeypointIndex::RightEar),
+    // 上半身
+    (KeypointIndex::LeftShoulder, KeypointIndex::RightShoulder),
+    (KeypointIndex::LeftShoulder, KeypointIndex::LeftElbow),
+    (KeypointIndex::LeftElbow, KeypointIndex::LeftWrist),
+    (KeypointIndex::RightShoulder, KeypointIndex::RightElbow),
+    (KeypointIndex::RightElbow, KeypointIndex::RightWrist),
+    // 胴体
+    (KeypointIndex::LeftShoulder, KeypointIndex::LeftHip),
+    (KeypointIndex::RightShoulder, KeypointIndex::RightHip),
+    (KeypointIndex::LeftHip, KeypointIndex::RightHip),
+    // 下半身
+    (KeypointIndex::LeftHip, KeypointIndex::LeftKnee),
+    (KeypointIndex::LeftKnee, KeypointIndex::LeftAnkle),
+    (KeypointIndex::RightHip, KeypointIndex::RightKnee),
+    (KeypointIndex::RightKnee, KeypointIndex::RightAnkle),
+];
+
+/// キーポイントの色 (RGB)
+pub const KEYPOINT_COLOR: u32 = 0x00FF00; // 緑
+
+/// 骨格線の色 (RGB)
+pub const SKELETON_COLOR: u32 = 0xFFFF00; // 黄色
+
+/// 信頼度が低いキーポイントの色 (RGB)
+pub const LOW_CONFIDENCE_COLOR: u32 = 0xFF0000; // 赤

--- a/src/render/window.rs
+++ b/src/render/window.rs
@@ -1,0 +1,170 @@
+use anyhow::Result;
+use minifb::{Key, Window, WindowOptions};
+use opencv::core::Mat;
+use opencv::prelude::*;
+
+use crate::pose::Pose;
+use crate::render::skeleton::{KEYPOINT_COLOR, LOW_CONFIDENCE_COLOR, SKELETON_COLOR, SKELETON_CONNECTIONS};
+
+/// minifbを使用したレンダラー
+pub struct MinifbRenderer {
+    window: Window,
+    buffer: Vec<u32>,
+    width: usize,
+    height: usize,
+}
+
+impl MinifbRenderer {
+    /// ウィンドウを作成
+    pub fn new(title: &str, width: usize, height: usize) -> Result<Self> {
+        let window = Window::new(
+            title,
+            width,
+            height,
+            WindowOptions {
+                resize: false,
+                ..WindowOptions::default()
+            },
+        )?;
+
+        let buffer = vec![0u32; width * height];
+
+        Ok(Self {
+            window,
+            buffer,
+            width,
+            height,
+        })
+    }
+
+    /// ウィンドウが開いているか
+    pub fn is_open(&self) -> bool {
+        self.window.is_open() && !self.window.is_key_down(Key::Escape)
+    }
+
+    /// 指定キーが押されたか（押した瞬間のみ true）
+    pub fn is_key_pressed(&self, key: Key) -> bool {
+        self.window.is_key_pressed(key, minifb::KeyRepeat::No)
+    }
+
+    /// BGR/BGRA Mat をバッファにコピー
+    pub fn draw_frame(&mut self, frame: &Mat) -> Result<()> {
+        self.draw_frame_at(frame, 0, 0)
+    }
+
+    /// BGR/BGRA Mat をバッファの指定オフセットにコピー
+    pub fn draw_frame_at(&mut self, frame: &Mat, x_offset: usize, y_offset: usize) -> Result<()> {
+        let frame_width = frame.cols() as usize;
+        let frame_height = frame.rows() as usize;
+        let channels = frame.channels() as usize;
+        let data = frame.data_bytes()?;
+        let step = frame.mat_step().get(0) as usize;
+        let copy_w = if x_offset < self.width { (self.width - x_offset).min(frame_width) } else { 0 };
+        let copy_h = if y_offset < self.height { (self.height - y_offset).min(frame_height) } else { 0 };
+
+        for y in 0..copy_h {
+            let row_start = y * step;
+            let buf_start = (y + y_offset) * self.width + x_offset;
+            for x in 0..copy_w {
+                let px = row_start + x * channels;
+                let b = data[px] as u32;
+                let g = data[px + 1] as u32;
+                let r = data[px + 2] as u32;
+                self.buffer[buf_start + x] = (r << 16) | (g << 8) | b;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// 姿勢を描画
+    pub fn draw_pose(&mut self, pose: &Pose, confidence_threshold: f32) {
+        let w = self.width as u32;
+        let h = self.height as u32;
+
+        // 骨格線を描画
+        for (start_idx, end_idx) in SKELETON_CONNECTIONS.iter() {
+            let start = pose.get(*start_idx);
+            let end = pose.get(*end_idx);
+
+            if start.is_valid(confidence_threshold) && end.is_valid(confidence_threshold) {
+                let (x1, y1) = start.to_pixel(w, h);
+                let (x2, y2) = end.to_pixel(w, h);
+                self.draw_line(x1, y1, x2, y2, SKELETON_COLOR);
+            }
+        }
+
+        // キーポイントを描画
+        for kp in pose.keypoints.iter() {
+            let (px, py) = kp.to_pixel(w, h);
+            let color = if kp.is_valid(confidence_threshold) {
+                KEYPOINT_COLOR
+            } else {
+                LOW_CONFIDENCE_COLOR
+            };
+            self.draw_circle(px, py, 4, color);
+        }
+    }
+
+    /// バッファをウィンドウに表示
+    pub fn update(&mut self) -> Result<()> {
+        self.window
+            .update_with_buffer(&self.buffer, self.width, self.height)?;
+        Ok(())
+    }
+
+    /// Bresenhamのアルゴリズムで線を描画
+    fn draw_line(&mut self, x0: i32, y0: i32, x1: i32, y1: i32, color: u32) {
+        let dx = (x1 - x0).abs();
+        let dy = -(y1 - y0).abs();
+        let sx = if x0 < x1 { 1 } else { -1 };
+        let sy = if y0 < y1 { 1 } else { -1 };
+        let mut err = dx + dy;
+
+        let mut x = x0;
+        let mut y = y0;
+
+        loop {
+            self.set_pixel(x, y, color);
+
+            if x == x1 && y == y1 {
+                break;
+            }
+
+            let e2 = 2 * err;
+            if e2 >= dy {
+                err += dy;
+                x += sx;
+            }
+            if e2 <= dx {
+                err += dx;
+                y += sy;
+            }
+        }
+    }
+
+    /// 円を描画（塗りつぶし）
+    fn draw_circle(&mut self, cx: i32, cy: i32, radius: i32, color: u32) {
+        for dy in -radius..=radius {
+            for dx in -radius..=radius {
+                if dx * dx + dy * dy <= radius * radius {
+                    self.set_pixel(cx + dx, cy + dy, color);
+                }
+            }
+        }
+    }
+
+    /// ピクセルをセット（境界チェック付き）
+    fn set_pixel(&mut self, x: i32, y: i32, color: u32) {
+        if x >= 0 && x < self.width as i32 && y >= 0 && y < self.height as i32 {
+            self.buffer[y as usize * self.width + x as usize] = color;
+        }
+    }
+
+    /// バッファインデックスに直接書き込み
+    pub fn set_pixel_raw(&mut self, index: usize, color: u32) {
+        if index < self.buffer.len() {
+            self.buffer[index] = color;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
#49 で誤って削除された calibrate / generate_board ツールとその依存モジュールを復元。これらは tracker_bevy とは無関係の独立ツール。

## Changes
- `src/bin/calibrate.rs`, `src/bin/generate_board.rs` を復元
- 依存モジュール復元: `calibration`, `camera`, `render`, `config`
- `config.rs` は `CalibrationConfig` のみに絞った軽量版（旧 tracker_bevy 設定は含まない）
- `config.toml` は `[calibration]` セクションのみ
- `calibration`, `camera`, `render` は `#[cfg(feature = "imgproc")]` でゲート
- Cargo.toml に minifb 依存と opencv の calib3d/objdetect feature を追加
- CLAUDE.md の Modules / ツールセクションを更新

---
🤖 *This PR was created via [Claude Code](https://claude.ai/claude-code)*